### PR TITLE
Adds OSE support matrix to DefaultImagestreamTemplate Overview, other edits

### DIFF
--- a/install_config/default_imagestreams_templates.adoc
+++ b/install_config/default_imagestreams_templates.adoc
@@ -16,64 +16,126 @@ toc::[]
 
 ifdef::openshift-enterprise[]
 Your OpenShift installation includes a useful set of Red Hat-provided
-link:../architecture/core_concepts/builds_and_image_streams.html#image-streams[image streams] and
-link:../architecture/core_concepts/templates.html[templates] to
+link:../architecture/core_concepts/builds_and_image_streams.html#image-streams[image
+streams] and link:../architecture/core_concepts/templates.html[templates] to
 make it easy for developers to create new applications. By default, the
 link:../install_config/install/quick_install.html[quick installation] and
-link:../install_config/install/advanced_install.html[advanced installation] methods automatically create
-these sets in the *openshift* project, which is a default project to which all
-users have view access.
+link:../install_config/install/advanced_install.html[advanced installation]
+methods automatically create these sets in the *openshift* project, which is a
+default global project to which all users have view access.
 endif::[]
+
 ifdef::openshift-origin[]
 You can populate your OpenShift installation with a useful set of Red
 Hat-provided
 link:../../architecture/core_concepts/builds_and_image_streams.html#image-streams[image
-streams] 
-and link:../../architecture/core_concepts/templates.html[templates] to
+streams] and link:../../architecture/core_concepts/templates.html[templates] to
 make it easy for developers to create new applications. By default, the
 link:advanced_install.html[advanced installation] method automatically creates
 these sets in the *openshift* project, which is a default project to which all
 users have view access.
 endif::[]
 
-Use the following instructions to create the objects
-yourself. The files are installed on the file system of your master.
-
-[NOTE]
-====
-This topic is only necessary if you installed OpenShift using a method other
-than the 
 ifdef::openshift-enterprise[]
-link:../install_config/install/quick_install.html[quick installation] or the
-link:../install_config/install/advanced_install.html[advanced installation]. 
+The core set of image streams and templates are provided and supported by Red Hat
+with an active OpenShift Enterprise subscription for the following technologies:
+
+[horizontal]
+Languages::
+- link:../using_images/s2i_images/nodejs.html[Node.js]
+- link:../using_images/s2i_images/perl.html[Perl]
+- link:../using_images/s2i_images/php.html[PHP]
+- link:../using_images/s2i_images/python.html[Python]
+- link:../using_images/s2i_images/ruby.html[Ruby]
+Database::
+- link:../using_images/db_images/mongodb.html[MongoDB]
+- link:../using_images/db_images/mysql.html[MySQL]
+- link:../using_images/db_images/postgresql.html[PostgreSQL]
+Other Services::
+- link:../using_images/other_images/jenkins.html[Jenkins]
+endif::[]
+
+ifdef::openshift-origin[]
+Image streams and templates are provided for the following technologies:
+
+[horizontal]
+Languages::
+- link:../../using_images/s2i_images/nodejs.html[Node.js]
+- link:../../using_images/s2i_images/perl.html[Perl]
+- link:../../using_images/s2i_images/php.html[PHP]
+- link:../../using_images/s2i_images/python.html[Python]
+- link:../../using_images/s2i_images/ruby.html[Ruby]
+Database::
+- link:../../using_images/db_images/mongodb.html[MongoDB]
+- link:../../using_images/db_images/mysql.html[MySQL]
+- link:../../using_images/db_images/postgresql.html[PostgreSQL]
+Other Services::
+- link:../../using_images/other_images/jenkins.html[Jenkins]
+endif::[]
+
+ifdef::openshift-enterprise[]
+If you also have the relevant xPaaS Middleware subscription active on your
+account, image streams and templates are also provided and supported by Red Hat
+for each of following middleware services:
+
+[horizontal]
+Middleware Services::
+- link:../using_images/xpaas_images/eap.html[JBoss EAP]
+- link:../using_images/xpaas_images/a_mq.html[JBoss A-MQ]
+- link:../using_images/xpaas_images/jws.html[JBoss Web Server]
+- link:../using_images/xpaas_images/fuse.html[JBoss Fuse Integration Services]
+- link:../using_images/xpaas_images/decision_server.html[Decision Server]
+- link:../using_images/xpaas_images/data_grid.html[JBoss Data Grid]
+endif::[]
+
+You can check which default image streams and templates are currently available
+in your OpenShift environment by logging into the web console and clicking *Add
+to Project*, or getting the lists for the *openshift* project using the CLI:
+
+----
+$ oc get is -n openshift
+$ oc get templates -n openshift
+----
+
+The JSON object definitions used to create these sets are installed on the file
+system of your master during
+ifdef::openshift-enterprise[]
+a link:../install_config/install/quick_install.html[quick] or
+link:../install_config/install/advanced_install.html[advanced installation].
 endif::[]
 ifdef::openshift-origin[]
-link:../../install_config/install/quick_install.html[quick installation] or the
-link:../../install_config/install/advanced_install.html[advanced installation]. 
+an link:../../install_config/install/advanced_install.html[advanced
+installation].
 endif::[]
-Image 
-streams and templates will be automatically populated in the `openshift` project 
-when using these methods.
-====
+If you used another method to install, or if the default image streams and
+templates are ever removed or changed, you can use the following instructions to
+create the default objects yourself. Otherwise, the following instructions are
+not necessary.
 
-[[prerequisites]]
-
+[[is-templates-prereqs]]
 == Prerequisites
-- The 
+
+Before you can create the default image streams and templates (if they do not
+already exist):
+
+- The
 ifdef::openshift-enterprise[]
-link:../install_config/install/docker_registry.html[integrated Docker registry] 
+link:../install_config/install/docker_registry.html[integrated Docker registry]
 endif::[]
 ifdef::openshift-origin[]
-link:../../install_config/install/docker_registry.html[integrated Docker registry] 
+link:../../install_config/install/docker_registry.html[integrated Docker
+registry]
 endif::[]
 service must be
 deployed in your OpenShift installation.
 - You must be able to run the following CLI commands with
 ifdef::openshift-enterprise[]
-link:../architecture/additional_concepts/authorization.html#roles[*cluster-admin* privileges],
+link:../architecture/additional_concepts/authorization.html#roles[*cluster-admin*
+privileges],
 endif::[]
 ifdef::openshift-origin[]
-link:../../architecture/additional_concepts/authorization.html#roles[*cluster-admin* privileges],
+link:../../architecture/additional_concepts/authorization.html#roles[*cluster-admin*
+privileges],
 endif::[]
 because they operate on the default *openshift*
 ifdef::openshift-enterprise[]
@@ -82,21 +144,37 @@ endif::[]
 ifdef::openshift-origin[]
 link:../../architecture/core_concepts/projects_and_users.html#projects[project].
 endif::[]
-- You must have cloned the https://github.com/openshift/openshift-ansible/tree/master/roles/openshift_examples/files[repository] that contains the supported imagestreams:
+ifdef::openshift-origin[]
+- You must have cloned the
+https://github.com/openshift/openshift-ansible/tree/master/roles/openshift_examples/files[repository]
+that contains the default image streams and templates:
 +
 ----
+$ cd ~
 $ git clone https://github.com/openshift/openshift-ansible
 ----
+endif::[]
+ifdef::openshift-enterprise[]
+- You must have installed the *atomic-openshift-utils* RPM package. See
+link:../install_config/install/prerequisites.html#software-prerequisites[Software
+Prerequisites] for instructions.
+endif::[]
 - Define shell variables for the directories containing image streams and templates. This significantly shortens the commands in the following sections. To do this:
 +
 ifdef::openshift-origin[]
 ----
-$ IMAGESTREAMDIR="/usr/share/ansible/openshift-ansible/roles/openshift_examples/files/examples/v1.1/image-streams"; DBTEMPLATES="/usr/share/ansible/openshift-ansible/roles/openshift_examples/files/examples/v1.1/db-templates"; QSTEMPLATES="/usr/share/ansible/openshift-ansible/roles/openshift_examples/files/examples/v1.1/quickstart-templates"
+$ IMAGESTREAMDIR="~/openshift-ansible/roles/openshift_examples/files/examples/v1.1/image-streams"; \
+    DBTEMPLATES="~/openshift-ansible/roles/openshift_examples/files/examples/v1.1/db-templates"; \
+    QSTEMPLATES="~/openshift-ansible/roles/openshift_examples/files/examples/v1.1/quickstart-templates"
 ----
 endif::[]
 ifdef::openshift-enterprise[]
 ----
-$ IMAGESTREAMDIR="/usr/share/ansible/openshift-ansible/roles/openshift_examples/files/examples/v1.1/image-streams"; XPAASSTREAMDIR="/usr/share/ansible/openshift-ansible/roles/openshift_examples/files/examples/v1.1/xpaas-streams"; XPAASTEMPLATES="/usr/share/ansible/openshift-ansible/roles/openshift_examples/files/examples/v1.1/xpaas-templates"; DBTEMPLATES="/usr/share/ansible/openshift-ansible/roles/openshift_examples/files/examples/v1.1/db-templates"; QSTEMPLATES="/usr/share/ansible/openshift-ansible/roles/openshift_examples/files/examples/v1.1/quickstart-templates"
+$ IMAGESTREAMDIR="/usr/share/ansible/openshift-ansible/roles/openshift_examples/files/examples/v1.1/image-streams"; \
+    XPAASSTREAMDIR="/usr/share/ansible/openshift-ansible/roles/openshift_examples/files/examples/v1.1/xpaas-streams"; \
+    XPAASTEMPLATES="/usr/share/ansible/openshift-ansible/roles/openshift_examples/files/examples/v1.1/xpaas-templates"; \
+    DBTEMPLATES="/usr/share/ansible/openshift-ansible/roles/openshift_examples/files/examples/v1.1/db-templates"; \
+    QSTEMPLATES="/usr/share/ansible/openshift-ansible/roles/openshift_examples/files/examples/v1.1/quickstart-templates"
 ----
 endif::[]
 
@@ -112,7 +190,7 @@ link:../using_images/s2i_images/python.html[*Python*], and
 link:../using_images/s2i_images/ruby.html[*Ruby*] applications. It also
 defines images for link:../using_images/db_images/mongodb.html[*MongoDB*],
 link:../using_images/db_images/mysql.html[*MySQL*], and
-link:../using_images/db_images/postgresql.html[*PostgreSQL*] 
+link:../using_images/db_images/postgresql.html[*PostgreSQL*]
 endif::[]
 ifdef::openshift-origin[]
 link:../../using_images/s2i_images/nodejs.html[*Node.js*],
@@ -122,7 +200,7 @@ link:../../using_images/s2i_images/python.html[*Python*], and
 link:../../using_images/s2i_images/ruby.html[*Ruby*] applications. It also
 defines images for link:../../using_images/db_images/mongodb.html[*MongoDB*],
 link:../../using_images/db_images/mysql.html[*MySQL*], and
-link:../../using_images/db_images/postgresql.html[*PostgreSQL*] 
+link:../../using_images/db_images/postgresql.html[*PostgreSQL*]
 endif::[]
 to support data storage.
 
@@ -149,9 +227,12 @@ ifdef::openshift-enterprise[]
 == Creating Image Streams for xPaaS Middleware Images
 The xPaaS Middleware image streams provide images for
 link:../using_images/xpaas_images/eap.html[*JBoss EAP*],
-link:../using_images/xpaas_images/jws.html[*JBoss JWS*], and
-link:../using_images/xpaas_images/a_mq.html[*JBoss A-MQ*]. They can be used
-to build applications for those platforms using the provided templates.
+link:../using_images/xpaas_images/jws.html[*JBoss JWS*],
+link:../using_images/xpaas_images/a_mq.html[*JBoss A-MQ*],
+link:../using_images/xpaas_images/fuse.html[*JBoss Fuse Integration Services*],
+link:../using_images/xpaas_images/decision_server.html[*Decision Server*], and
+link:../using_images/xpaas_images/data_grid.html[*JBoss Data Grid*]. They can be
+used to build applications for those platforms using the provided templates.
 
 To create the xPaaS Middleware set of image streams:
 
@@ -174,12 +255,12 @@ utilized by other components. For each database
 ifdef::openshift-enterprise[]
 (link:../using_images/db_images/mongodb.html[*MongoDB*],
 link:../using_images/db_images/mysql.html[*MySQL*], and
-link:../using_images/db_images/postgresql.html[*PostgreSQL*]), 
+link:../using_images/db_images/postgresql.html[*PostgreSQL*]),
 endif::[]
 ifdef::openshift-origin[]
 (link:../../using_images/db_images/mongodb.html[*MongoDB*],
 link:../../using_images/db_images/mysql.html[*MySQL*], and
-link:../../using_images/db_images/postgresql.html[*PostgreSQL*]), 
+link:../../using_images/db_images/postgresql.html[*PostgreSQL*]),
 endif::[]
 two templates are defined.
 
@@ -213,17 +294,17 @@ The InstantApp templates define a full set of objects for a running application.
 These include:
 
 ifdef::openshift-enterprise[]
-- link:../architecture/core_concepts/builds_and_image_streams.html#builds[Build configurations] 
+- link:../architecture/core_concepts/builds_and_image_streams.html#builds[Build configurations]
 endif::[]
 ifdef::openshift-origin[]
-- link:../../architecture/core_concepts/builds_and_image_streams.html#builds[Build configurations] 
+- link:../../architecture/core_concepts/builds_and_image_streams.html#builds[Build configurations]
 endif::[]
 to build the application from source located in a GitHub public repository
 ifdef::openshift-enterprise[]
-- link:../architecture/core_concepts/deployments.html#deployments-and-deployment-configurations[Deployment configurations] 
+- link:../architecture/core_concepts/deployments.html#deployments-and-deployment-configurations[Deployment configurations]
 endif::[]
 ifdef::openshift-origin[]
-- link:../../architecture/core_concepts/deployments.html#deployments-and-deployment-configurations[Deployment configurations] 
+- link:../../architecture/core_concepts/deployments.html#deployments-and-deployment-configurations[Deployment configurations]
 endif::[]
 to deploy the application image after it is built.
 ifdef::openshift-enterprise[]
@@ -240,10 +321,10 @@ ifdef::openshift-origin[]
 link:../../architecture/core_concepts/pods_and_services.html#pods[pods].
 endif::[]
 ifdef::openshift-enterprise[]
-- link:../architecture/core_concepts/routes.html[Routes] 
+- link:../architecture/core_concepts/routes.html[Routes]
 endif::[]
 ifdef::openshift-origin[]
-- link:../../architecture/core_concepts/routes.html[Routes] 
+- link:../../architecture/core_concepts/routes.html[Routes]
 endif::[]
 to provide external access to the application.
 
@@ -252,8 +333,9 @@ application can perform database operations.
 
 [NOTE]
 ====
-The templates which define a database use ephemeral storage for the database content.  These templates should be used
-for demonstration purposes only as all database data will be lost if the database pod restarts for any reason.
+The templates which define a database use ephemeral storage for the database
+content. These templates should be used for demonstration purposes only as all
+database data will be lost if the database pod restarts for any reason.
 ====
 
 After creating the templates, users are able to easily instantiate full
@@ -271,9 +353,12 @@ $ oc create -f $QSTEMPLATES -n openshift
 ifdef::openshift-enterprise[]
 There is also a set of templates for creating applications using various xPaaS
 Middleware products (link:../using_images/xpaas_images/eap.html[*JBoss EAP*],
-link:../using_images/xpaas_images/jws.html[*JBoss JWS*], and
-link:../using_images/xpaas_images/a_mq.html[*JBoss A-MQ*]), which can be
-registered by running:
+link:../using_images/xpaas_images/jws.html[*JBoss JWS*],
+link:../using_images/xpaas_images/a_mq.html[*JBoss A-MQ*],
+link:../using_images/xpaas_images/fuse.html[*JBoss Fuse Integration Services*],
+link:../using_images/xpaas_images/decision_server.html[*Decision Server*], and
+link:../using_images/xpaas_images/data_grid.html[*JBoss Data Grid*]), which can
+be registered by running:
 
 ----
 $ oc create -f $XPAASTEMPLATES -n openshift
@@ -282,8 +367,9 @@ $ oc create -f $XPAASTEMPLATES -n openshift
 [NOTE]
 ====
 The xPaaS Middleware templates require the
-link:../install_config/default_imagestreams_templates.html#creating-image-streams-for-xpaas-middleware-images[xPaaS Middleware image
-streams], which in turn require the relevant xPaaS Middleware subscriptions.
+link:../install_config/default_imagestreams_templates.html#creating-image-streams-for-xpaas-middleware-images[xPaaS
+Middleware image streams], which in turn require the relevant xPaaS Middleware
+subscriptions.
 ====
 
 [NOTE]
@@ -300,17 +386,17 @@ endif::[]
 
 With these artifacts created, developers can now
 ifdef::openshift-enterprise[]
-link:../dev_guide/authentication.html[log into the web console] 
+link:../dev_guide/authentication.html[log into the web console]
 endif::[]
 ifdef::openshift-origin[]
-link:../../dev_guide/authentication.html[log into the web console] 
+link:../../dev_guide/authentication.html[log into the web console]
 endif::[]
 and follow the flow for
 ifdef::openshift-enterprise[]
-link:../dev_guide/templates.html#creating-from-templates-using-the-web-console[creating from a template]. 
+link:../dev_guide/templates.html#creating-from-templates-using-the-web-console[creating from a template].
 endif::[]
 ifdef::openshift-origin[]
-link:../../dev_guide/templates.html#creating-from-templates-using-the-web-console[creating from a template]. 
+link:../../dev_guide/templates.html#creating-from-templates-using-the-web-console[creating from a template].
 endif::[]
 Any of the database or application templates can be selected
 to create a running database service or application in the current project. Note
@@ -326,10 +412,10 @@ their own applications.
 
 You can direct your developers to the
 ifdef::openshift-enterprise[]
-link:../dev_guide/templates.html#using-the-instantapp-templates[Using the InstantApp Templates] 
+link:../dev_guide/templates.html#using-the-instantapp-templates[Using the InstantApp Templates]
 endif::[]
 ifdef::openshift-origin[]
-link:../../dev_guide/templates.html#using-the-instantapp-templates[Using the InstantApp Templates] 
+link:../../dev_guide/templates.html#using-the-instantapp-templates[Using the InstantApp Templates]
 endif::[]
 section in the Developer Guide for these instructions.
 // end::firststeps[]

--- a/install_config/install/first_steps.adoc
+++ b/install_config/install/first_steps.adoc
@@ -11,4 +11,3 @@
 toc::[]
 
 include::install_config/default_imagestreams_templates.adoc[tag=firststeps]
-


### PR DESCRIPTION
Per unrelated PM request (hijacking your PR since work was already underway in this topic, and it seems like the best place to put it), adds a clear list in the Overview for the available image streams and templates, and for OSE makes a distinction about what comes w/ the core OSE subscription vs the xPaaS Middleware subs. Still seeking verification on the language about the xPaaS subs tho (will update here again).

Also returned the Origin directory paths to the ~/openshift-ansible style, because for Origin there's no atomic-openshift-utils for them to install. We are telling them to git clone the openshift-ansible repo, so we should be setting the directory path env vars according to that.

Also other minor edits for clarity.
